### PR TITLE
Switch to Alpine Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.13-slim
+FROM library/python:3.13.0-alpine3.20
 
 # Install curl
-RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u8
+RUN apk --no-cache add "curl=8.11.0-r2"
 
 WORKDIR /app
 
-RUN useradd -ms /bin/bash gw
+RUN addgroup -S gw && adduser -S gw -G gw
 USER gw
 WORKDIR /home/gw
 


### PR DESCRIPTION
The Checkmarx One Container Security scanner suggests that this is a lot safer than the Debian image we used before.