### PR TITLE
Enable custom package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ authors = [
 
 [project.urls]
 homepage = "https://github.com/james-bostock-cx/gitlab-webhook"
+
+[tool.setuptools.packages]
+find = {}


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery

Without this, the building of the Docker image fails.